### PR TITLE
feat: add sync command for quick home-manager updates

### DIFF
--- a/config/nvim/config/plugins.lua
+++ b/config/nvim/config/plugins.lua
@@ -23,6 +23,10 @@ require("lazy").setup({
         dependencies = { "nvim-lua/plenary.nvim" },
     },
     { 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' },
+    {
+    "nvim-telescope/telescope-file-browser.nvim",
+    dependencies = { "nvim-telescope/telescope.nvim", "nvim-lua/plenary.nvim" }
+},
     { "machakann/vim-sandwich" },
     { "rhysd/clever-f.vim" },
     { "iberianpig/tig-explorer.vim" },

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,9 @@
     system = "aarch64-darwin";
     pkgs = import nixpkgs {inherit system;};
   in {
+    apps.${system} = {
     # nix run .#update
-    apps.${system}.update = {
+    update = {
       type = "app";
       program = toString (pkgs.writeShellScript "update-script" ''
         set -e
@@ -30,6 +31,18 @@
         nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
         echo "Update complete!"
       '');
+    };
+
+    # nix run .#sync
+    sync = {
+      type = "app";
+      program = toString (pkgs.writeShellScript "sync-script" ''
+        set -e
+        echo "Syncing home-manager configuration..."
+        nix run nixpkgs#home-manager -- switch --flake .#myHomeConfig
+        echo "Sync complete! Config changes applied."
+      '');
+    };
     };
 
     homeConfigurations = {


### PR DESCRIPTION
## Summary
- Add `nix run .#sync` command for quick home-manager configuration updates
- Allows faster iteration when editing nvim config files without running flake update

## Test plan
- [ ] Test `nix run .#sync` command works correctly
- [ ] Verify nvim config changes are applied after running sync
- [ ] Confirm existing `nix run .#update` command still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)